### PR TITLE
Added CCA method

### DIFF
--- a/test/test_calculate_cca.py
+++ b/test/test_calculate_cca.py
@@ -1,0 +1,67 @@
+from __future__ import division
+
+import unittest
+
+import numpy as np
+np.random.seed(42)
+
+from wyrm.types import Data
+from wyrm.processing import append, swapaxes, calculate_cca
+
+
+class TestCalculateCCA(unittest.TestCase):
+
+    SAMPLES = 100
+    CHANNELS_X = 10
+    CHANNELS_Y = 5
+
+    def setUp(self):
+        # create a random noise signals with
+        # X: 100 samplse and 10 channels
+        # Y: 100 samples and 5 channels
+        self.X = np.random.randn(self.SAMPLES, self.CHANNELS_X)
+        self.Y = np.random.randn(self.SAMPLES, self.CHANNELS_Y)
+        axes_x = [np.arange(self.X.shape[0]), np.arange(self.X.shape[1])]
+        axes_y = [np.arange(self.Y.shape[0]), np.arange(self.Y.shape[1])]
+        self.dat_x = Data(self.X, axes=axes_x, names=['time', 'channel'], units=['ms', '#'])
+        self.dat_y = Data(self.Y, axes=axes_y, names=['time', 'channel'], units=['ms', '#'])
+
+    def test_rho(self):
+        """Test if the canonical correlation is between 0 and 1."""
+        rho, w_x, w_y = calculate_cca(self.dat_x, self.dat_y)
+        self.assertTrue(0 < rho <1)
+
+    def test_raise_error_with_non_continuous_data(self):
+        """Raise error if ``dat_x`` is not continuous Data object."""
+        dat = Data(np.random.randn(2, self.SAMPLES, self.CHANNELS_X),
+                   axes=[[0, 1], self.dat_x.axes[0], self.dat_x.axes[1]],
+                   names=['class', 'time', 'channel'],
+                   units=['#', 'ms', '#'])
+        with self.assertRaises(AssertionError):
+            calculate_cca(dat, self.dat_x)
+
+    def test_raise_error_with_different_length_data(self):
+        """Raise error if the length of ``dat_x`` and ``dat_y`` is different."""
+        dat = append(self.dat_x, self.dat_x)
+        with self.assertRaises(AssertionError):
+            calculate_cca(dat, self.dat_y)
+
+    def test_calculate_csp_swapaxes(self):
+        """caluclate_cca must work with nonstandard timeaxis."""
+        res1 = calculate_cca(swapaxes(self.dat_x, 0, 1), swapaxes(self.dat_y, 0, 1), timeaxis=1)
+        res2 = calculate_cca(self.dat_x, self.dat_y)
+        np.testing.assert_array_equal(res1[0], res2[0])
+        np.testing.assert_array_equal(res1[1], res2[1])
+        np.testing.assert_array_equal(res1[2], res2[2])
+
+    def test_calculate_cca_copy(self):
+        """caluclate_cca must not modify argument."""
+        cpy_x = self.dat_x.copy()
+        cpy_y = self.dat_y.copy()
+        calculate_cca(self.dat_x, self.dat_y)
+        self.assertEqual(self.dat_x, cpy_x)
+        self.assertEqual(self.dat_y, cpy_y)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_calculate_cca.py
+++ b/test/test_calculate_cca.py
@@ -46,7 +46,7 @@ class TestCalculateCCA(unittest.TestCase):
         with self.assertRaises(AssertionError):
             calculate_cca(dat, self.dat_y)
 
-    def test_calculate_csp_swapaxes(self):
+    def test_calculate_cca_swapaxes(self):
         """caluclate_cca must work with nonstandard timeaxis."""
         res1 = calculate_cca(swapaxes(self.dat_x, 0, 1), swapaxes(self.dat_y, 0, 1), timeaxis=1)
         res2 = calculate_cca(self.dat_x, self.dat_y)

--- a/wyrm/processing.py
+++ b/wyrm/processing.py
@@ -1839,18 +1839,11 @@ def calculate_classwise_average(dat, classaxis=0):
 
 
 def calculate_cca(dat_x, dat_y, timeaxis=-2):
-    """Calculate the Canonical Correlation Analysis (CCA) of specified data.
+    """Calculate the Canonical Correlation Analysis (CCA).
 
-    This method calculates the canonical correlation and the corresponding weights.
-
-    Examples
-    --------
-    Calculate the CCA for the specified multivariable signals.
-
-    >>> rho, w_x, w_y = calculate_cca(dat_x, dat_y)
-    >>> # Obtain canonical variables
-    >>> cv_x = np.dot(dat_x, w_x)
-    >>> cv_y = np.dot(dat_y, w_y)
+    This method calculates the canonical correlation coefficient and
+    corresponding weights which maximize a correlation coefficient
+    between linear combinations of the two specified multivariable signals.
 
     Parameters
     ----------
@@ -1862,9 +1855,10 @@ def calculate_cca(dat_x, dat_y, timeaxis=-2):
     Returns
     -------
     rho : float
-        the canonical correlation.
+        the canonical correlation coefficient.
     w_x, w_y : 1d array
-        the weights corresponding to each canonical variable.
+        the weights for mapping from the specified multivariable signals to
+        canonical variables.
 
     Raises
     ------
@@ -1872,6 +1866,15 @@ def calculate_cca(dat_x, dat_y, timeaxis=-2):
         If:
           * ``dat_x`` and ``dat_y`` is not continuous Data object
           * the length of ``dat_x`` and ``dat_y`` is different on the ``timeaxis``
+
+    Examples
+    --------
+    Calculate the CCA of the specified multivariable signals.
+
+    >>> rho, w_x, w_y = calculate_cca(dat_x, dat_y)
+    >>> # Calculate canonical variables via obtained weights
+    >>> cv_x = np.dot(dat_x, w_x)
+    >>> cv_y = np.dot(dat_y, w_y)
 
     References
     ----------

--- a/wyrm/processing.py
+++ b/wyrm/processing.py
@@ -1902,11 +1902,11 @@ def calculate_cca(dat_x, dat_y, timeaxis=-2):
     ic_xx = np.linalg.pinv(c_xx)
     ic_yy = np.linalg.pinv(c_yy)
     # calculate w_x
-    w, v = np.linalg.eigh(reduce(np.dot, [ic_xx, c_xy, ic_yy, c_yx]))
+    w, v = np.linalg.eig(reduce(np.dot, [ic_xx, c_xy, ic_yy, c_yx]))
     w_x = v[:, np.argmax(w)]
     w_x = w_x / np.sqrt(reduce(np.dot, [w_x.T, c_xx, w_x]))
     # calculate w_y
-    w, v = np.linalg.eigh(reduce(np.dot, [ic_yy, c_yx, ic_xx, c_xy]))
+    w, v = np.linalg.eig(reduce(np.dot, [ic_yy, c_yx, ic_xx, c_xy]))
     w_y = v[:, np.argmax(w)]
     w_y = w_y / np.sqrt(reduce(np.dot, [w_y.T, c_yy, w_y]))
     # calculate rho

--- a/wyrm/processing.py
+++ b/wyrm/processing.py
@@ -1904,11 +1904,11 @@ def calculate_cca(dat_x, dat_y, timeaxis=-2):
     ic_yy = np.linalg.pinv(c_yy)
     # calculate w_x
     w, v = np.linalg.eig(functools.reduce(np.dot, [ic_xx, c_xy, ic_yy, c_yx]))
-    w_x = v[:, np.argmax(w)]
+    w_x = v[:, np.argmax(w)].real
     w_x = w_x / np.sqrt(functools.reduce(np.dot, [w_x.T, c_xx, w_x]))
     # calculate w_y
     w, v = np.linalg.eig(functools.reduce(np.dot, [ic_yy, c_yx, ic_xx, c_xy]))
-    w_y = v[:, np.argmax(w)]
+    w_y = v[:, np.argmax(w)].real
     w_y = w_y / np.sqrt(functools.reduce(np.dot, [w_y.T, c_yy, w_y]))
     # calculate rho
     rho = abs(functools.reduce(np.dot, [w_x.T, c_xy, w_y]))

--- a/wyrm/processing.py
+++ b/wyrm/processing.py
@@ -10,6 +10,7 @@ This module contains the processing methods.
 
 from __future__ import division
 
+import functools
 import logging
 import re
 
@@ -1902,15 +1903,15 @@ def calculate_cca(dat_x, dat_y, timeaxis=-2):
     ic_xx = np.linalg.pinv(c_xx)
     ic_yy = np.linalg.pinv(c_yy)
     # calculate w_x
-    w, v = np.linalg.eig(reduce(np.dot, [ic_xx, c_xy, ic_yy, c_yx]))
+    w, v = np.linalg.eig(functools.reduce(np.dot, [ic_xx, c_xy, ic_yy, c_yx]))
     w_x = v[:, np.argmax(w)]
-    w_x = w_x / np.sqrt(reduce(np.dot, [w_x.T, c_xx, w_x]))
+    w_x = w_x / np.sqrt(functools.reduce(np.dot, [w_x.T, c_xx, w_x]))
     # calculate w_y
-    w, v = np.linalg.eig(reduce(np.dot, [ic_yy, c_yx, ic_xx, c_xy]))
+    w, v = np.linalg.eig(functools.reduce(np.dot, [ic_yy, c_yx, ic_xx, c_xy]))
     w_y = v[:, np.argmax(w)]
-    w_y = w_y / np.sqrt(reduce(np.dot, [w_y.T, c_yy, w_y]))
+    w_y = w_y / np.sqrt(functools.reduce(np.dot, [w_y.T, c_yy, w_y]))
     # calculate rho
-    rho = abs(np.dot(w_x.T, np.dot(c_xy, w_y)))
+    rho = abs(functools.reduce(np.dot, [w_x.T, c_xy, w_y]))
     return rho, w_x, w_y
 
 


### PR DESCRIPTION
Hi, @venthur 

I added the Canonical Correlation Analysis (CCA) method to the processing.py.
I know the CCA is already implemented in the scikit-learn, but I think it is redundant.
The reason of why I re-implemented it, I want a simple CCA method for the SSVEP based BCI.
I would be glad if you could merge this pull request :)
