### PR TITLE
fix casting error on numpy 1.11.0 when loading brain vision data

### DIFF
--- a/wyrm/io.py
+++ b/wyrm/io.py
@@ -163,7 +163,7 @@ def load_brain_vision_data(vhdr):
     # load EEG data
     logger.debug('Loading EEG Data.')
     data = np.fromfile(data_f, np.int16)
-    data = data.reshape(-1, n_channels)
+    data = data.reshape(-1, n_channels).astype(type(resolutions[0]))
     data *= resolutions[0]
     n_samples = data.shape[0]
     # duration in ms


### PR DESCRIPTION
the previous version was triggering the error:

TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int64') with casting rule 'same_kind'

explicit casting is necessary to about this
